### PR TITLE
feat: implementar dependencia require_role para autorización basada en roles

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -5,7 +5,9 @@ from infrastructure.database import get_db
 from infrastructure.models import UserORM
 from infrastructure.auth_provider import AuthProvider
 from domain.entities import User
+from domain.enums import Role
 from api.dependencies import get_current_user
+from api.guards import require_role
 
 router = APIRouter()
 
@@ -13,9 +15,7 @@ router = APIRouter()
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     """
     Autentica al usuario y devuelve un token JWT.
-    
-    **Nota:** Por convención del estándar OAuth2, el campo se llama `username`, 
-    pero debes enviar el **email** del usuario.
+    **Nota:** Enviar el email en el campo `username`.
     """
     user_orm = db.query(UserORM).filter(UserORM.email == form_data.username).first()
     if not user_orm or not AuthProvider.verify_password(form_data.password, user_orm.hashed_password):
@@ -29,10 +29,12 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
     )
     return {"access_token": access_token, "token_type": "bearer"}
 
-@router.get("/me", summary="Obtener perfil de usuario")
+# Endpoint accesible para cualquier usuario autenticado (OPERATOR o superior)
+@router.get("/me", dependencies=[Depends(require_role(Role.OPERATOR))], summary="Obtener perfil de usuario")
 def get_me(current_user: User = Depends(get_current_user)):
     """
-    Retorna los datos del usuario actualmente autenticado (Entidad del dominio).
+    Retorna los datos del usuario actualmente autenticado.
+    Requiere rol mínimo: OPERATOR.
     """
     return {
         "id": current_user.id,

--- a/backend/api/guards.py
+++ b/backend/api/guards.py
@@ -1,22 +1,30 @@
-from fastapi import HTTPException, status, Depends
+from fastapi import Depends, HTTPException, status
 from domain.entities import User
 from domain.enums import Role
 from api.dependencies import get_current_user
 
-class RoleChecker:
-    def __init__(self, allowed_roles: list[Role]):
-        self.allowed_roles = allowed_roles
-
-    def __call__(self, user: User = Depends(get_current_user)) -> User:
-        if user.role not in self.allowed_roles:
-            roles_str = [r.value for r in self.allowed_roles]
+def require_role(required_role: Role):
+    """
+    Dependencia de FastAPI que verifica si el usuario autenticado tiene el rol necesario.
+    Implementa una jerarquía: ADMIN tiene acceso a todo, SUPERVISOR a lo suyo y lo de OPERATOR.
+    """
+    def role_checker(current_user: User = Depends(get_current_user)) -> User:
+        # Definimos la jerarquía de permisos
+        hierarchy = {
+            Role.ADMIN: [Role.ADMIN, Role.SUPERVISOR, Role.OPERATOR],
+            Role.SUPERVISOR: [Role.SUPERVISOR, Role.OPERATOR],
+            Role.OPERATOR: [Role.OPERATOR]
+        }
+        
+        # Obtenemos los roles permitidos para el nivel requerido
+        allowed_roles = hierarchy.get(required_role, [])
+        
+        if current_user.role not in allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Acceso denegado. Se requiere uno de estos roles: {roles_str}"
+                detail=f"Acceso denegado. Se requiere el nivel de acceso: {required_role.value}"
             )
-        return user
+        
+        return current_user
 
-# Definición de dependencias
-is_admin = RoleChecker([Role.ADMIN])
-is_supervisor_or_admin = RoleChecker([Role.ADMIN, Role.SUPERVISOR])
-is_any_role = RoleChecker([Role.ADMIN, Role.SUPERVISOR, Role.OPERATOR])
+    return role_checker


### PR DESCRIPTION
[x] Se creó la dependencia require_role(role: Role) en guards.py.

[x] Se configuró una jerarquía de acceso usando los roles válidos del dominio (ADMIN, SUPERVISOR, OPERATOR).

[x] La dependencia retorna 403 Forbidden si el usuario no tiene los permisos suficientes.

[x] Se integró con get_current_user para asegurar el 401 Unauthorized si el token es inválido o expiró.

[x] Se protegió el endpoint GET /me exigiendo rol de OPERATOR como mínimo.

Closes #4 