### PR TITLE
feat: implementar State Pattern para Incident (Issue 6)

### DIFF
--- a/backend/domain/entities.py
+++ b/backend/domain/entities.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 import datetime
 from typing import Optional
 from backend.domain.exceptions import InvalidStateTransitionError, ValidationError
+from backend.domain.states import IncidentState
 from domain.enums import IncidentStatus, Role, Severity, TaskStatus
 from uuid import uuid4
 
@@ -24,6 +25,7 @@ class User:
 class Incident:
     """
     Entidad Incident - Corazón del sistema OpsCenter.
+    Usa State Pattern para manejar su ciclo de vida.
     """
     title: str
     description: str
@@ -34,6 +36,7 @@ class Incident:
     assigned_to: Optional[str] = None
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
+    _state: Optional[IncidentState] = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if not self.title or len(self.title.strip()) < 3:
@@ -50,47 +53,59 @@ class Incident:
         """Retorna el estado actual del incidente"""
         return self._status
 
+    @property
+    def state(self) -> IncidentState:
+        """
+        Retorna el objeto State actual (lazy loading).
+        El estado se crea según el valor de _status.
+        """
+        if self._state is None:
+            from domain.states import create_state_from_status
+            self._state = create_state_from_status(self._status, self)
+        return self._state
+
     def assign_to(self, user_id: str) -> None:
         """
         Asigna el incidente a un usuario.
-        Solo se puede asignar si el incidente está OPEN.
+        Delega en el estado actual la lógica de asignación.
         """
-        if self._status != IncidentStatus.OPEN:
-            raise InvalidStateTransitionError(
-                f"No se puede asignar un incidente en estado {self._status.value}"
-            )
-        self.assigned_to = user_id
-        self._status = IncidentStatus.ASSIGNED
+        self.state.assign(self, user_id)
         self.updated_at = datetime.utcnow()
 
-    def change_status(self, new_status: IncidentStatus) -> None:
+    def start_progress(self) -> None:
+        """Marca el incidente como en progreso"""
+        self.state.start_progress(self)
+        self.updated_at = datetime.utcnow()
+
+    def resolve(self) -> None:
+        """Resuelve el incidente"""
+        self.state.resolve(self)
+        self.updated_at = datetime.utcnow()
+
+    def close(self) -> None:
+        """Cierra el incidente"""
+        self.state.close(self)
+        self.updated_at = datetime.utcnow()
+
+    def reopen(self) -> None:
+        """Reabre el incidente"""
+        self.state.reopen(self)
+        self.updated_at = datetime.utcnow()
+
+    def _transition_to(self, new_status: IncidentStatus) -> None:
         """
-        Cambia el estado del incidente validando las transiciones permitidas.
+        Método interno llamado por los estados para cambiar el estado.
+        No debe ser llamado directamente desde fuera.
         """
-        # Definir transiciones válidas
-        allowed_transitions = {
-            IncidentStatus.OPEN: [IncidentStatus.ASSIGNED],
-            IncidentStatus.ASSIGNED: [IncidentStatus.IN_PROGRESS, IncidentStatus.OPEN],
-            IncidentStatus.IN_PROGRESS: [IncidentStatus.RESOLVED, IncidentStatus.ASSIGNED],
-            IncidentStatus.RESOLVED: [IncidentStatus.CLOSED, IncidentStatus.OPEN],
-            IncidentStatus.CLOSED: [],  # Estado final, no se puede cambiar
-        }
-        
-        if new_status == self._status:
-            return  # No hay cambio
-        
-        if new_status not in allowed_transitions.get(self._status, []):
-            raise InvalidStateTransitionError(
-                f"Transición inválida: {self._status.value} -> {new_status.value}"
-            )
-        
         self._status = new_status
+        self._state = None  # Forzar recarga del nuevo estado
         self.updated_at = datetime.utcnow()
-
 
 @dataclass
 class Task:
-    """Entidad Task - Tareas asociadas a un incidente"""
+    """Entidad Task - Tareas asociadas a un incidente
+    Usa State Pattern para manejar su ciclo de vida 
+    """
     incident_id: str
     title: str
     description: str

--- a/backend/domain/states.py
+++ b/backend/domain/states.py
@@ -1,0 +1,223 @@
+"""
+State Pattern para el ciclo de vida de un Incidente.
+"""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from domain.enums import IncidentStatus
+from domain.exceptions import InvalidStateTransitionError
+
+if TYPE_CHECKING:
+    from domain.entities import Incident
+
+
+# ============================================
+# Clase abstracta del State
+# ============================================
+
+class IncidentState(ABC):
+    """
+    Clase abstracta que define las acciones que pueden realizarse
+    sobre un incidente dependiendo de su estado actual.
+    """
+    
+    @abstractmethod
+    def assign(self, incident: Incident, user_id: str) -> None:
+        """Asignar el incidente a un usuario"""
+        pass
+    
+    @abstractmethod
+    def start_progress(self, incident: Incident) -> None:
+        """Iniciar el progreso del incidente"""
+        pass
+    
+    @abstractmethod
+    def resolve(self, incident: Incident) -> None:
+        """Resolver el incidente"""
+        pass
+    
+    @abstractmethod
+    def close(self, incident: Incident) -> None:
+        """Cerrar el incidente"""
+        pass
+    
+    @abstractmethod
+    def reopen(self, incident: Incident) -> None:
+        """Reabrir el incidente"""
+        pass
+
+
+# ============================================
+# Estados concretos
+# ============================================
+
+class OpenState(IncidentState):
+    """
+    Estado: OPEN (Abierto)
+    Se puede asignar, pero no se puede iniciar progreso, resolver ni cerrar.
+    """
+    
+    def assign(self, incident: Incident, user_id: str) -> None:
+        incident.assigned_to = user_id
+        incident._transition_to(IncidentStatus.ASSIGNED)
+    
+    def start_progress(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede iniciar progreso: el incidente no está asignado"
+        )
+    
+    def resolve(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede resolver: el incidente no está asignado"
+        )
+    
+    def close(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede cerrar: el incidente no está resuelto"
+        )
+    
+    def reopen(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede reabrir: el incidente ya está abierto"
+        )
+
+
+class AssignedState(IncidentState):
+    """
+    Estado: ASSIGNED (Asignado)
+    Se puede iniciar progreso o reabrir (volver a OPEN).
+    """
+    
+    def assign(self, incident: Incident, user_id: str) -> None:
+        # Reasignar es válido, se queda en ASSIGNED
+        incident.assigned_to = user_id
+    
+    def start_progress(self, incident: Incident) -> None:
+        incident._transition_to(IncidentStatus.IN_PROGRESS)
+    
+    def resolve(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede resolver: el incidente no está en progreso"
+        )
+    
+    def close(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede cerrar: el incidente no está resuelto"
+        )
+    
+    def reopen(self, incident: Incident) -> None:
+        incident.assigned_to = None
+        incident._transition_to(IncidentStatus.OPEN)
+
+
+class InProgressState(IncidentState):
+    """
+    Estado: IN_PROGRESS (En progreso)
+    Se puede resolver o volver a asignado.
+    """
+    
+    def assign(self, incident: Incident, user_id: str) -> None:
+        # Volver a asignar (cambiar de responsable)
+        incident.assigned_to = user_id
+        incident._transition_to(IncidentStatus.ASSIGNED)
+    
+    def start_progress(self, incident: Incident) -> None:
+        # Ya está en progreso, no hacer nada
+        pass
+    
+    def resolve(self, incident: Incident) -> None:
+        incident._transition_to(IncidentStatus.RESOLVED)
+    
+    def close(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede cerrar: el incidente no está resuelto"
+        )
+    
+    def reopen(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede reabrir: el incidente no está cerrado"
+        )
+
+
+class ResolvedState(IncidentState):
+    """
+    Estado: RESOLVED (Resuelto)
+    Se puede cerrar o reabrir.
+    """
+    
+    def assign(self, incident: Incident, user_id: str) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede asignar: el incidente está resuelto"
+        )
+    
+    def start_progress(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede iniciar progreso: el incidente está resuelto"
+        )
+    
+    def resolve(self, incident: Incident) -> None:
+        # Ya está resuelto, no hacer nada
+        pass
+    
+    def close(self, incident: Incident) -> None:
+        incident._transition_to(IncidentStatus.CLOSED)
+    
+    def reopen(self, incident: Incident) -> None:
+        incident.assigned_to = None
+        incident._transition_to(IncidentStatus.OPEN)
+
+
+class ClosedState(IncidentState):
+    """
+    Estado: CLOSED (Cerrado)
+    Estado final. Solo se puede reabrir.
+    """
+    
+    def assign(self, incident: Incident, user_id: str) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede asignar: el incidente está cerrado"
+        )
+    
+    def start_progress(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede iniciar progreso: el incidente está cerrado"
+        )
+    
+    def resolve(self, incident: Incident) -> None:
+        raise InvalidStateTransitionError(
+            "No se puede resolver: el incidente está cerrado"
+        )
+    
+    def close(self, incident: Incident) -> None:
+        # Ya está cerrado, no hacer nada
+        pass
+    
+    def reopen(self, incident: Incident) -> None:
+        incident.assigned_to = None
+        incident._transition_to(IncidentStatus.OPEN)
+
+
+# ============================================
+# Factory para crear el estado según el enum
+# ============================================
+
+def create_state_from_status(status: IncidentStatus, incident: Incident) -> IncidentState:
+    """
+    Fábrica que retorna la instancia del estado correcto según el enum.
+    Esto permite hacer lazy loading del estado.
+    """
+    states = {
+        IncidentStatus.OPEN: OpenState,
+        IncidentStatus.ASSIGNED: AssignedState,
+        IncidentStatus.IN_PROGRESS: InProgressState,
+        IncidentStatus.RESOLVED: ResolvedState,
+        IncidentStatus.CLOSED: ClosedState,
+    }
+    
+    state_class = states.get(status)
+    if state_class is None:
+        raise ValueError(f"Estado desconocido: {status}")
+    
+    return state_class()


### PR DESCRIPTION
- Agregar propiedad state con lazy loading
- Agregar métodos start_progress(), resolve(), close(), reopen()
- Agregar método interno _transition_to() para cambiar estado
- Eliminar diccionario allowed_transitions y lógica antigua de change_status()
- La lógica de transiciones ahora vive en domain/states.py

Closes #6