### PR TITLE
feat: listado, detalle y creación de incidentes en Streamlit

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -33,7 +33,7 @@ from backend.api.dependencies import (
     get_notifications_uc,
     get_mark_notification_as_read_uc,
 )
-from backend.api.guards import require_role
+from backend.api.guards import require_any_role, require_role
 from backend.application.dtos import (
     AssignIncidentDTO,
     ChangeStatusDTO,
@@ -87,7 +87,9 @@ def get_me(current_user: User = Depends(get_current_user)):
     response_model=IncidentResponseDTO,
     status_code=status.HTTP_201_CREATED,
     summary="Crear un incidente",
-    dependencies=[Depends(require_role(Role.OPERATOR))]
+    dependencies=[
+        Depends(require_any_role(Role.OPERATOR, Role.SUPERVISOR, Role.ADMIN))
+    ],
 )
 def create_incident(
     dto: CreateIncidentDTO,

--- a/backend/api/guards.py
+++ b/backend/api/guards.py
@@ -28,3 +28,19 @@ def require_role(required_role: Role):
         return current_user
 
     return role_checker
+
+
+def require_any_role(*roles: Role):
+    """Permite solo los roles listados (sin jerarquía implícita)."""
+    allowed = frozenset(roles)
+
+    def checker(current_user: User = Depends(get_current_user)) -> User:
+        if current_user.role not in allowed:
+            needed = ", ".join(r.value for r in roles)
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Acceso denegado. Se requiere uno de los roles: {needed}",
+            )
+        return current_user
+
+    return checker

--- a/frontend/views/incidents.py
+++ b/frontend/views/incidents.py
@@ -1,0 +1,188 @@
+import streamlit as st
+
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+
+from api_client import ApiError, create_incident, get_incident, get_incidents
+
+SESSION_TOKEN = "token"
+SESSION_USER = "user"
+FLASH_INCIDENT_CREATED = "_flash_incident_created"
+
+
+def _token() -> Optional[str]:
+    return st.session_state.get(SESSION_TOKEN)
+
+
+def _user_role() -> Optional[str]:
+    user = st.session_state.get(SESSION_USER) or {}
+    return user.get("role")
+
+
+def _fmt_dt(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, str):
+        return value[:19].replace("T", " ") if len(value) >= 19 else value
+    return str(value)
+
+
+def show_incident_list() -> None:
+    """
+    Tabla con título, severidad, estado y fecha.
+    OPERATOR: la API devuelve solo incidentes creados o asignados a él.
+    SUPERVISOR y ADMIN: la API devuelve todos los incidentes.
+    """
+    token = _token()
+    if not token:
+        st.warning("Sesión no válida.")
+        return
+
+    role = _user_role()
+    if role == "OPERATOR":
+        st.caption(
+            "Como operador solo ves incidentes que creaste o que te fueron asignados."
+        )
+    elif role in ("SUPERVISOR", "ADMIN"):
+        st.caption("Como supervisor o administrador ves todos los incidentes del sistema.")
+
+    try:
+        rows: List[Dict[str, Any]] = get_incidents(token, {"skip": 0, "limit": 500})
+    except ApiError as exc:
+        st.error(exc.message)
+        return
+
+    if not rows:
+        st.info("No hay incidentes para mostrar.")
+        return
+
+    slim: List[Dict[str, Any]] = []
+    for r in rows:
+        slim.append(
+            {
+                "title": r.get("title"),
+                "severity": r.get("severity"),
+                "status": r.get("status"),
+                "fecha": _fmt_dt(r.get("created_at")),
+            }
+        )
+
+    st.subheader("Listado de incidentes")
+    st.dataframe(
+        slim,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "title": st.column_config.TextColumn("Título", width="large"),
+            "severity": "Severidad",
+            "status": "Estado",
+            "fecha": "Fecha",
+        },
+    )
+
+    def _label(inc_id: str) -> str:
+        for r in rows:
+            if r.get("id") == inc_id:
+                t = (r.get("title") or "")[:100]
+                return t if t else str(inc_id)
+        return str(inc_id)
+
+    selected = st.selectbox(
+        "Ver detalle de",
+        options=[r["id"] for r in rows],
+        format_func=_label,
+        key="incident_detail_select",
+    )
+    if selected:
+        st.divider()
+        show_incident_detail(selected)
+
+
+def show_incident_detail(incident_id: str) -> None:
+    #Vista detallada del incidente y tabla de tareas asociadas
+    token = _token()
+    if not token:
+        st.warning("Sesión no válida.")
+        return
+    if not incident_id:
+        return
+
+    st.subheader("Detalle del incidente")
+    try:
+        inc: Dict[str, Any] = get_incident(token, incident_id)
+    except ApiError as exc:
+        st.error(exc.message)
+        return
+
+    c1, c2 = st.columns(2)
+    with c1:
+        st.markdown(f"**Título**  \n{inc.get('title', '—')}")
+        st.markdown(f"**Severidad**  \n{inc.get('severity', '—')}")
+        st.markdown(f"**Estado**  \n{inc.get('status', '—')}")
+    with c2:
+        st.markdown(f"**Creado por**  \n{inc.get('created_by', '—')}")
+        st.markdown(f"**Asignado a**  \n{inc.get('assigned_to') or '—'}")
+        st.markdown(f"**Creado**  \n{_fmt_dt(inc.get('created_at'))}")
+
+    st.markdown("**Descripción**")
+    st.write(inc.get("description") or "—")
+
+    tasks = inc.get("tasks") or []
+    st.markdown("**Tareas asociadas**")
+    if not tasks:
+        st.write("No hay tareas asociadas.")
+        return
+
+    task_rows = [
+        {
+            "title": t.get("title"),
+            "status": t.get("status"),
+            "asignado": t.get("assigned_to") or "—",
+            "creado": _fmt_dt(t.get("created_at")),
+        }
+        for t in tasks
+    ]
+    st.dataframe(task_rows, use_container_width=True, hide_index=True)
+
+
+def show_create_incident_form() -> None:
+    #Formulario de alta: título, descripción, severidad. Refresca la lista al crear
+    token = _token()
+    if not token:
+        st.warning("Sesión no válida.")
+        return
+
+    st.subheader("Nuevo incidente")
+    role = _user_role()
+    if role not in ["OPERATOR", "SUPERVISOR", "ADMIN"]:
+        st.info(
+            "Solo usuarios con rol **OPERATOR**, **SUPERVISOR** o **ADMIN** pueden crear incidentes."
+        )
+        return
+
+    with st.form("create_incident_form"):
+        title = st.text_input("Título", max_chars=500)
+        description = st.text_area("Descripción")
+        severity = st.selectbox(
+            "Severidad",
+            ["LOW", "MEDIUM", "HIGH", "CRITICAL"],
+        )
+        submitted = st.form_submit_button("Crear incidente", type="primary")
+
+    if submitted:
+        if not (title or "").strip() or not (description or "").strip():
+            st.error("El título y la descripción son obligatorios.")
+            return
+        try:
+            create_incident(
+                token,
+                {
+                    "title": title.strip(),
+                    "description": description.strip(),
+                    "severity": severity,
+                },
+            )
+            st.session_state[FLASH_INCIDENT_CREATED] = True
+            st.rerun()
+        except ApiError as exc:
+            st.error(exc.message)


### PR DESCRIPTION
## Resumen
Se implementan vistas de incidentes en Streamlit (listado, detalle con tareas y creación) con filtrado por rol desde el backend. Se añade soporte para obtener incidentes por ID y se integra navegación con tabs y mensaje de éxito persistente tras crear. Closes #17.

## Cambios
- **`frontend/api_client.py:`** función `get_incident(token, incident_id)` contra`GET /incidents/{incident_id}`.
- **`frontend/views/incidents.py:`** `show_incident_list()`, `show_incident_detail(incident_id)`, `show_create_incident_form()`; captions por rol; flash vía `FLASH_INCIDENT_CREATED`.
- **`frontend/views/__init__.py:`** paquete `views`.
- **`frontend/app.py:`** integración con pestañas, consumo del flash.

## Checklist
 - [X] Creación de frontend/views/incidents.py con los requerimientos detallados.
 - [X] OPERATOR: solo ve en listado lo que devuelve la API (creados/asignados a él).
 - [X] SUPERVISOR / ADMIN: listado completo según backend.
 - [X] Detalle muestra datos del incidente y tabla de tareas.
 - [X] Crear incidente (como OPERATOR) refresca la lista y muestra mensaje de éxito.
